### PR TITLE
Feature/updated revocation data downloader

### DIFF
--- a/cert-extensions/pom.xml
+++ b/cert-extensions/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: X.509 Certificate Extensions</name>

--- a/cert-validation/pom.xml
+++ b/cert-validation/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: X.509 Certificate Validation</name>

--- a/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/http/DefaultRevocationDataConnector.java
+++ b/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/http/DefaultRevocationDataConnector.java
@@ -1,0 +1,42 @@
+package se.swedenconnect.sigval.cert.validity.http;
+
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.cert.ocsp.OCSPReq;
+import org.bouncycastle.cert.ocsp.OCSPResp;
+import se.swedenconnect.sigval.cert.validity.crl.impl.CRLDataLoader;
+import se.swedenconnect.sigval.cert.validity.ocsp.OCSPDataLoader;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Standard Revocation data connector for downloading revocation data resources
+ *
+ * @author Martin Lindström (martin@idsec.se)
+ * @author Stefan Santesson (stefan@idsec.se)
+ */
+@Slf4j
+@NoArgsConstructor
+public class DefaultRevocationDataConnector extends GenericHttpConnector implements CRLDataLoader, OCSPDataLoader {
+
+  private static final Map<String, String> ocspProperties;
+
+  static {
+    ocspProperties = new HashMap<>();
+    ocspProperties.put("Content-Type", "application/ocsp-request");
+    ocspProperties.put("Accept", "application/ocsp-response");
+  }
+
+  @Override public byte[] downloadCrl(String url, int connectTimeout, int readTimeout) throws IOException {
+    final HttpResponse httpResponse = getResource(new URL(url), connectTimeout, readTimeout);
+    return httpResponse.getData();
+  }
+
+  @Override public OCSPResp requestOCSPResponse(String url, OCSPReq ocspReq, int connectTimeout, int readTimeout) throws IOException {
+    final HttpResponse response = getResource(new URL(url), connectTimeout, readTimeout, ocspReq.getEncoded(), ocspProperties);
+    return new OCSPResp(response.getData());
+  }
+}

--- a/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/http/DefaultRevocationDataConnector.java
+++ b/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/http/DefaultRevocationDataConnector.java
@@ -22,6 +22,7 @@ import java.util.Map;
 @NoArgsConstructor
 public class DefaultRevocationDataConnector extends GenericHttpConnector implements CRLDataLoader, OCSPDataLoader {
 
+  /** Map holding the standard OCSP HTTP request properties */
   private static final Map<String, String> ocspProperties;
 
   static {
@@ -30,11 +31,13 @@ public class DefaultRevocationDataConnector extends GenericHttpConnector impleme
     ocspProperties.put("Accept", "application/ocsp-response");
   }
 
+  /** {@inheritDoc} */
   @Override public byte[] downloadCrl(String url, int connectTimeout, int readTimeout) throws IOException {
     final HttpResponse httpResponse = getResource(new URL(url), connectTimeout, readTimeout);
     return httpResponse.getData();
   }
 
+  /** {@inheritDoc} */
   @Override public OCSPResp requestOCSPResponse(String url, OCSPReq ocspReq, int connectTimeout, int readTimeout) throws IOException {
     final HttpResponse response = getResource(new URL(url), connectTimeout, readTimeout, ocspReq.getEncoded(), ocspProperties);
     return new OCSPResp(response.getData());

--- a/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/http/GenericHttpConnector.java
+++ b/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/http/GenericHttpConnector.java
@@ -1,0 +1,119 @@
+package se.swedenconnect.sigval.cert.validity.http;
+
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Description
+ *
+ * @author Martin Lindström (martin@idsec.se)
+ * @author Stefan Santesson (stefan@idsec.se)
+ */
+@Slf4j
+@NoArgsConstructor
+public class GenericHttpConnector {
+
+  public HttpResponse getResource(URL requestUrl, int connectTimeout, int readTimeout){
+    return getResource(requestUrl, connectTimeout, readTimeout, null, null);
+  }
+  public HttpResponse getResource(URL requestUrl, int connectTimeout, int readTimeout, byte[] data, Map<String, String> propertyMap){
+    try {
+      String method = data == null ? "GET" : "POST";
+      propertyMap = propertyMap == null ? new HashMap<>() : propertyMap;
+      HttpURLConnection connection = (HttpURLConnection) requestUrl.openConnection();
+      connection.setRequestMethod(method);
+      connection.setDoOutput(false);
+      connection.setDoInput(true);
+      if (connection instanceof HttpsURLConnection){
+        ((HttpsURLConnection)connection).setSSLSocketFactory(getSSLContext().getSocketFactory());
+      }
+      for (String property : propertyMap.keySet()){
+        connection.setRequestProperty(property, propertyMap.get(property));
+      }
+      connection.setConnectTimeout(connectTimeout);
+      connection.setReadTimeout(readTimeout);
+      if (data != null){
+        connection.setDoOutput(true);
+        OutputStream out = connection.getOutputStream();
+        try {
+          IOUtils.write(data, out);
+          out.flush();
+        }
+        finally {
+          IOUtils.close(out);
+        }
+      }
+      connection.connect();
+
+      int responseCode = connection.getResponseCode();
+      byte[] bytes;
+      try {
+        if (responseCode > 205 || responseCode < 200) {
+          bytes = IOUtils.toByteArray(connection.getErrorStream());
+        }
+        else {
+          bytes = IOUtils.toByteArray(connection.getInputStream());
+        }
+      }
+      catch (IOException ex) {
+        log.debug("Error receiving http data stream {}", ex.toString());
+        return HttpResponse.builder()
+          .data(null)
+          .exception(ex)
+          .responseCode(responseCode)
+          .build();
+      }
+      return HttpResponse.builder()
+        .data(bytes)
+        .exception(null)
+        .responseCode(responseCode)
+        .build();
+    }
+    catch (Exception ex) {
+      log.debug("Error setting up HTTP connection {}", ex.toString());
+      return HttpResponse.builder()
+        .data(null)
+        .exception(ex)
+        .responseCode(0)
+        .build();
+    }
+  }
+
+  private SSLContext getSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
+    final SSLContext sslContext = SSLContext.getInstance("SSL");
+    sslContext.init(null, new TrustManager[]{new TrustAllTrustManager()}, new SecureRandom());
+    return sslContext;
+  }
+
+  @NoArgsConstructor
+  public static class TrustAllTrustManager implements X509TrustManager {
+    @Override public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+    }
+
+    @Override public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+    }
+
+    @Override public X509Certificate[] getAcceptedIssuers() {
+      return null;
+    }
+  }
+
+
+}

--- a/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/http/GenericHttpConnector.java
+++ b/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/http/GenericHttpConnector.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Description
+ * Generic implementation of HTTP GET and POST to support download of revocation data
  *
  * @author Martin Lindström (martin@idsec.se)
  * @author Stefan Santesson (stefan@idsec.se)
@@ -30,9 +30,26 @@ import java.util.Map;
 @NoArgsConstructor
 public class GenericHttpConnector {
 
+  /**
+   * Get resource from URL using HTTP GET
+   * @param requestUrl url for the resource
+   * @param connectTimeout milliseconds allowed to establish an HTTP connection with the resource
+   * @param readTimeout milliseconds allowed to download the resource data
+   * @return response data
+   */
   public HttpResponse getResource(URL requestUrl, int connectTimeout, int readTimeout){
     return getResource(requestUrl, connectTimeout, readTimeout, null, null);
   }
+
+  /**
+   * Get resrouce from URL using either GET or POST. POST is automatically selected if some data to be posted is included as an argument
+   * @param requestUrl url for the resource
+   * @param connectTimeout milliseconds allowed to establish an HTTP connection with the resource
+   * @param readTimeout milliseconds allowed to download the resource data
+   * @param data data to be posted or null to select HTTP GET
+   * @param propertyMap map of HTTP connect properties to add to the HTTP connection. The map key is the property name and the map value is the property value
+   * @return response data
+   */
   public HttpResponse getResource(URL requestUrl, int connectTimeout, int readTimeout, byte[] data, Map<String, String> propertyMap){
     try {
       String method = data == null ? "GET" : "POST";
@@ -96,12 +113,21 @@ public class GenericHttpConnector {
     }
   }
 
+  /**
+   * Provide an SSL context that allows any TLS certificate issuer. No specific trust in the TLS certificate is required as all revocation data is signed
+   * @return {@link SSLContext}
+   * @throws NoSuchAlgorithmException algorithm is not supported
+   * @throws KeyManagementException error handling keys
+   */
   private SSLContext getSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
     final SSLContext sslContext = SSLContext.getInstance("SSL");
     sslContext.init(null, new TrustManager[]{new TrustAllTrustManager()}, new SecureRandom());
     return sslContext;
   }
 
+  /**
+   * Trust manager trusting all certificates
+   */
   @NoArgsConstructor
   public static class TrustAllTrustManager implements X509TrustManager {
     @Override public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {

--- a/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/http/HttpResponse.java
+++ b/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/http/HttpResponse.java
@@ -1,0 +1,26 @@
+package se.swedenconnect.sigval.cert.validity.http;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * HTTP response data
+ *
+ * @author Martin Lindström (martin@idsec.se)
+ * @author Stefan Santesson (stefan@idsec.se)
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class HttpResponse {
+
+  /** Data contained in the HTTP response */
+  byte[] data;
+  /** HTTP response code */
+  int responseCode;
+  /** Exception encountered */
+  Exception exception;
+}

--- a/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/ocsp/OCSPDataLoader.java
+++ b/cert-validation/src/main/java/se/swedenconnect/sigval/cert/validity/ocsp/OCSPDataLoader.java
@@ -25,10 +25,10 @@ public interface OCSPDataLoader {
 
   /**
    * Get an OCSP response from the
-   * @param url
-   * @param ocspReq
-   * @return
-   * @throws IOException
+   * @param url OCSP request URL
+   * @param ocspReq OCSP request to send to the OCSP responder
+   * @return OCSP Response
+   * @throws IOException Error sending or receiving data
    */
   OCSPResp requestOCSPResponse(String url, OCSPReq ocspReq, int connectTimeout, int readTimeout) throws IOException;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.swedenconnect.sigval</groupId>
   <artifactId>sigval-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.0</version>
+  <version>1.1.1-SNAPSHOT</version>
 
   <name>Sweden Connect :: Parent POM for Signature Validation</name>
   <description>Parent POM for SignService Validation libraries</description>

--- a/sigval-commons/pom.xml
+++ b/sigval-commons/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: Commons</name>

--- a/sigval-pdf/pom.xml
+++ b/sigval-pdf/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: PDF</name>

--- a/sigval-xml/pom.xml
+++ b/sigval-xml/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: XML</name>


### PR DESCRIPTION
This update fixes a problem with the previous default HTTP get and post implementations. The new default CRL data downloader accepts all certificates and implements timeouts correctly.