### PR TITLE
Release 1.3.4

### DIFF
--- a/cert-extensions/pom.xml
+++ b/cert-extensions/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: X.509 Certificate Extensions</name>

--- a/cert-validation/pom.xml
+++ b/cert-validation/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: X.509 Certificate Validation</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.swedenconnect.sigval</groupId>
   <artifactId>sigval-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.3.3</version>
+  <version>1.3.4</version>
 
   <name>Sweden Connect :: Parent POM for Signature Validation</name>
   <description>Parent POM for SignService Validation libraries</description>

--- a/sigval-commons/pom.xml
+++ b/sigval-commons/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: Commons</name>

--- a/sigval-jose/pom.xml
+++ b/sigval-jose/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: JOSE</name>

--- a/sigval-pdf/pom.xml
+++ b/sigval-pdf/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: PDF</name>

--- a/sigval-report/pom.xml
+++ b/sigval-report/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
   </parent>
 
   <artifactId>sigvalreport</artifactId>

--- a/sigval-xml/pom.xml
+++ b/sigval-xml/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: XML</name>


### PR DESCRIPTION
Updated parent POM version to 1.3.4 across modules and enhanced PDF signature context logic to allow safe annotation updates in signatures and document timestamps.