### PR TITLE
Release 2.0.1

### DIFF
--- a/cert-extensions/pom.xml
+++ b/cert-extensions/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: X.509 Certificate Extensions</name>

--- a/cert-validation/pom.xml
+++ b/cert-validation/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: X.509 Certificate Validation</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.swedenconnect.sigval</groupId>
   <artifactId>sigval-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
 
   <name>Sweden Connect :: Parent POM for Signature Validation</name>
   <description>Parent POM for SignService Validation libraries</description>

--- a/sigval-commons/pom.xml
+++ b/sigval-commons/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: Commons</name>

--- a/sigval-jose/pom.xml
+++ b/sigval-jose/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: JOSE</name>

--- a/sigval-pdf/pom.xml
+++ b/sigval-pdf/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: PDF</name>

--- a/sigval-pdf/src/main/java/se/swedenconnect/sigval/pdf/pdfstruct/impl/DefaultPDFSignatureContext.java
+++ b/sigval-pdf/src/main/java/se/swedenconnect/sigval/pdf/pdfstruct/impl/DefaultPDFSignatureContext.java
@@ -530,8 +530,16 @@ public class DefaultPDFSignatureContext implements PDFSignatureContext {
     }
 
     // Forbid adding any new non-/Annots keys
+    boolean hasTypedAnnots = false;
     for (COSName key : newDict.keySet()) {
-      if (!key.equals(COSName.ANNOTS) && !oldDict.containsKey(key)) {
+      if (!oldDict.containsKey(key)) {
+        if (key.equals(COSName.ANNOTS)) {
+          continue;
+        }
+        if (key.equals(COSName.TYPE) && COSName.ANNOT.equals(newDict.getCOSName(COSName.TYPE))) {
+          hasTypedAnnots = true;
+          continue;
+        }
         log.debug("Non root object added an unsafe non annotation item: {}", key);
         return false;
       }
@@ -542,6 +550,10 @@ public class DefaultPDFSignatureContext implements PDFSignatureContext {
     COSArray newAnnots = newDict.getCOSArray(COSName.ANNOTS);
 
     if (newAnnots == null) {
+      if (hasTypedAnnots) {
+        log.debug("New annotation list is null, but /Type is Annot. This is an annotation change");
+        return true;
+      }
       // if newAnnots is null, then this is an error because this function is only called if there is an xref change.
       // Since there are no new annotations, the change must be something else.
       log.debug("New annotation list is null, therefore the change is not an annotation change");

--- a/sigval-report/pom.xml
+++ b/sigval-report/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>sigvalreport</artifactId>

--- a/sigval-xml/pom.xml
+++ b/sigval-xml/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>sigval-parent</artifactId>
     <groupId>se.swedenconnect.sigval</groupId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <name>Sweden Connect :: Signature validation :: XML</name>


### PR DESCRIPTION
Update parent POM version to 2.0.1 across modules and improve PDF signature context logic to safely handle typed annotation updates.